### PR TITLE
Fix a couple mistakes in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,16 @@ This script can also be run in a Docker container.
 
 This script can be configured using environment variables, a `.env` file, or individual command-line arguments. Alternatively, it can be run with the `-i` or `--interactive` flag to interactively prompt for all configuration values. Command-line arguments always override environment variables.
 
-| Environment Variable       | Command-line Argument                   | Description                                                         | Default                       |
-| -------------------------- | --------------------------------------- | ------------------------------------------------------------------- | ----------------------------- |
-| N/A                        | `-i`, `--interactive`                   | Interactively prompt for all configuration values                   | N/A                           |
-| SSSL_NINTENDO_CA_G3_PATH   | `-g`, `--nintendo-ca-g3-path <value>`   | Path to Nintendo CA - G3 certificate (may be in DER or PEM format)  | `./CACERT_NINTENDO_CA_G3.der` |
-| SSSL_NINTENDO_CA_G3_FORMAT | `-f`, `--nintendo-ca-g3-format <value>` | Nintendo CA - G3 certificate format (must be "der" or "pem")        | `der`                         |
-| SSSL_CA_PRIVATE_KEY_PATH   | `-c`, `--ca-private-key-path <value>`   | Path to private key for forged CA (will generate if not set)        | N/A                           |
-| SSSL_SITE_PRIVATE_KEY_PATH | `-s`, `--site-private-key-path <value>` | Path to private key for site certificate (will generate if not set) | N/A                           |
-| SSSL_CSR_PATH              | `-r`, `--csr-path <value>`              | Path to CSR (will generate if not set)                              | N/A                           |
-| SSSL_COMMON_NAME           | `-n`, `--common-name <value>`           | CN for site certificate (see [the bugs](#the-bugs))                 | `*`                           |
-| SSSL_OUTPUT_FOLDER_PATH    | `-o`, `--output-folder-path <value>`    | Output folder                                                       | `./`                          |
+| Environment Variable       | Command-line Argument                    | Description                                                         | Default                       |
+| -------------------------- | ---------------------------------------- | ------------------------------------------------------------------- | ----------------------------- |
+| N/A                        | `-i`, `--interactive`                    | Interactively prompt for all configuration values                   | N/A                           |
+| SSSL_NINTENDO_CA_G3_PATH   | `-g3`, `--nintendo-ca-g3-path <value>`   | Path to Nintendo CA - G3 certificate (may be in DER or PEM format)  | `./CACERT_NINTENDO_CA_G3.der` |
+| SSSL_NINTENDO_CA_G3_FORMAT | `-f`, `--nintendo-ca-g3-format <value>`  | Nintendo CA - G3 certificate format (must be "der" or "pem")        | `der`                         |
+| SSSL_CA_PRIVATE_KEY_PATH   | `-cap`, `--ca-private-key-path <value>`  | Path to private key for forged CA (will generate if not set)        | N/A                           |
+| SSSL_SITE_PRIVATE_KEY_PATH | `-sp`, `--site-private-key-path <value>` | Path to private key for site certificate (will generate if not set) | N/A                           |
+| SSSL_CSR_PATH              | `-csrp`, `--csr-path <value>`            | Path to CSR (will generate if not set)                              | N/A                           |
+| SSSL_COMMON_NAME           | `-cn`, `--common-name <value>`           | CN for site certificate (see [the bugs](#the-bugs))                 | `*`                           |
+| SSSL_OUTPUT_FOLDER_PATH    | `-o`, `--output-folder-path <value>`     | Output folder                                                       | `./`                          |
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This script can also be run in a Docker container.
 1. `git clone https://github.com/PretendoNetwork/SSSL`
 2. `cd SSSL`
 3. `docker build . -t sssl`
-4. `docker run -it --rm -v .:/app sssl` or `docker run -it --rm -v .:/app sssl -i`
+4. `docker run -it --rm -v .:/app/certs sssl -g3 /app/certs/CACERT_NINTENDO_CA_G3.der -o /app/certs`
 
 ## Configuration
 


### PR DESCRIPTION
### Changes:

In #4, the short command-line options in the readme were incorrect. Also, the provided `docker run` command doesn't always work because mounting the current directory as /app in Docker overwrites the entire /app directory, which can cause `node_modules` to disappear. Instead, tell users to mount the current directory as /app/certs to avoid this.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.